### PR TITLE
Potential fix for code scanning alert no. 1: Unsafe jQuery plugin

### DIFF
--- a/src/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/src/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -684,7 +684,25 @@ $.extend( $.validator, {
 		},
 
 		clean: function( selector ) {
-			return $( selector )[ 0 ];
+
+			// If a jQuery object is passed, use its first element directly.
+			if ( selector && selector.jquery ) {
+				return selector[ 0 ];
+			}
+
+			// If a DOM element or window is passed, return it as-is.
+			if ( selector && ( selector.nodeType || selector === selector.window ) ) {
+				return selector;
+			}
+
+			// If a string is passed, treat it strictly as a selector, not HTML.
+			if ( typeof selector === "string" ) {
+				var context = this.currentForm || document;
+				return $( context ).find( selector )[ 0 ];
+			}
+
+			// For all other cases, return undefined.
+			return undefined;
 		},
 
 		errors: function() {


### PR DESCRIPTION
Potential fix for [https://github.com/ms-mfg-community/TechWorkshop-L300-GitHub-Copilot-and-platform/security/code-scanning/1](https://github.com/ms-mfg-community/TechWorkshop-L300-GitHub-Copilot-and-platform/security/code-scanning/1)

General approach: Prevent `validator.clean` from ever treating a string argument as raw HTML. When given a string, it should only be used as a *selector* against an existing context (the current form or `document`), not passed straight into `$` in a way that allows HTML parsing. For non-string inputs (elements, jQuery objects), behavior should remain unchanged.

Best concrete fix here: Update the `clean` method in `src/wwwroot/lib/jquery-validation/dist/jquery.validate.js` so that:

- If `selector` is a jQuery object, we just take its first element (`selector[0]`) as today.
- If `selector` is a DOM element or `window`, we return it as-is (again, equivalent to the current first-element semantics).
- If `selector` is a string, we **do not** call `$( selector )` directly. Instead, we interpret it strictly as a CSS selector and search within the current form if available, or `document` otherwise, using `.find(selector)` so that a string like `"<img src=x onerror=...>"` is not treated as HTML.
- If `selector` is anything else (null, undefined, unexpected types), we safely return `undefined`.

This preserves existing intended behavior:

- Internally, `clean` is currently called as `v.clean( v.findByName( name ) )`. `findByName` already returns a jQuery collection scoped to `this.currentForm`, so our new logic treats that as a jQuery object and returns the first element, just as before.
- External calls that used to pass a selector string like `"[name='field']"` will now be resolved *within* the form (or document) via `.find`, which is equivalent or more precise than `$( selector )` with respect to context, and does not allow HTML interpretation.

Implementation details:

- Only edit the `clean` function body at lines 686–688 in `src/wwwroot/lib/jquery-validation/dist/jquery.validate.js`.
- Use existing jQuery utilities (`$`, `document`) and basic `typeof` checks; no new imports are required.
- New logic:

  ```js
  clean: function( selector ) {
      // If a jQuery object is passed, use its first element directly.
      if ( selector && selector.jquery ) {
          return selector[ 0 ];
      }

      // If a DOM element or window is passed, return it as-is.
      if ( selector && ( selector.nodeType || selector === selector.window ) ) {
          return selector;
      }

      // If a string is passed, treat it strictly as a selector, not HTML.
      if ( typeof selector === "string" ) {
          var context = this.currentForm || document;
          return $( context ).find( selector )[ 0 ];
      }

      // For all other cases, return undefined.
      return undefined;
  },
  ```

This removes the possibility of creating DOM from untrusted HTML while maintaining compatibility for element/jQuery inputs and selector-string use.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
