### PR TITLE
Potential fix for code scanning alert no. 2: Unsafe jQuery plugin

### DIFF
--- a/src/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/src/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -684,6 +684,24 @@ $.extend( $.validator, {
 		},
 
 		clean: function( selector ) {
+
+			// If a jQuery object is passed, return its first DOM element
+			if ( selector && selector.jquery ) {
+				return selector[ 0 ] || null;
+			}
+
+			// If a DOM element is passed, return it directly
+			if ( selector && selector.nodeType === 1 ) {
+				return selector;
+			}
+
+			// Fallback: if a selector string or other value is passed,
+			// resolve it only within the current form context to avoid
+			// interpreting it as HTML.
+			if ( this.currentForm ) {
+				return $( this.currentForm ).find( selector )[ 0 ] || null;
+			}
+
 			return $( selector )[ 0 ];
 		},
 
@@ -1068,7 +1086,17 @@ $.extend( $.validator, {
 				element = this.findByName( element.name );
 			}
 
-			// Always apply ignore filter
+			// Normalize to a single DOM element
+			if ( element && element.jquery ) {
+				element = element[ 0 ];
+			}
+
+			// If we still don't have a DOM element, abort
+			if ( !element || element.nodeType !== 1 ) {
+				return undefined;
+			}
+
+			// Always apply ignore filter on a safe element reference
 			return $( element ).not( this.settings.ignore )[ 0 ];
 		},
 


### PR DESCRIPTION
Potential fix for [https://github.com/ms-mfg-community/TechWorkshop-L300-GitHub-Copilot-and-platform/security/code-scanning/2](https://github.com/ms-mfg-community/TechWorkshop-L300-GitHub-Copilot-and-platform/security/code-scanning/2)

General approach: Avoid calling `$(...)` on values that might be arbitrary strings where HTML parsing would be triggered. Instead, restrict `$(...)` to DOM elements/jQuery objects, or explicitly treat untrusted input as selectors via `.find(...)` or `.filter(...)` on a known safe context.

Best fix here:

1. **Harden `validationTargetFor(element)`** so that it:
   - Accepts only DOM elements / jQuery objects.
   - Never passes a raw string into `$()`.
   - If it does receive a string, it uses a safe selection strategy that interprets it as a selector relative to `this.currentForm` rather than as HTML.

2. **Harden `clean(selector)`** similarly, since CodeQL’s dataflow passes through this function:
   - Detect jQuery objects and DOM elements and return them directly.
   - Reject or safely handle plain strings rather than passing them straight to `$()`.

This preserves existing behavior for all current usages (which pass elements/jQuery objects) while closing the “unsafe jQuery plugin” pattern and addressing both variants that refer to `$.fn.validate` and `$.fn.rules`.

Concrete changes (all in `src/wwwroot/lib/jquery-validation/dist/jquery.validate.js`):

- Replace `clean: function( selector ) { return $( selector )[ 0 ]; },` with a version that:
  - If `selector` is a jQuery object: returns `selector[0] || null`.
  - If `selector` is a DOM element: returns it directly.
  - If it’s anything else (e.g., string): uses `$( this.currentForm ).find( selector )[0] || null` (safe selector resolution within the current form instead of HTML parsing).

- Replace `validationTargetFor`’s return line from `return $( element ).not( this.settings.ignore )[ 0 ];` to:
  - Normalize `element` to a DOM element (handling jQuery objects and ignoring unexpected types).
  - If we end up with no DOM element, return `undefined`.
  - Otherwise wrap that element with `$()` (safe, because it’s an element, not a string) and apply `.not( this.settings.ignore )[0]`.

No new imports or external libraries are needed; we only use existing `$`, `this.currentForm`, and `this.settings`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
